### PR TITLE
fix: correct stop array initialization

### DIFF
--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -227,7 +227,7 @@ export async function generateTrueOrFalse({
 
     const modelSettings = getModelSettings(runtime.modelProvider, modelClass);
     const stop = Array.from(
-        new Set([...(modelSettings.stop || []), ["\n"]])
+        new Set([...(modelSettings.stop || []), "\n"])
     ) as string[];
 
     while (retryCount < MAX_RETRIES) {


### PR DESCRIPTION
Stop token was in a nested array in generateTrueOrFalse function