### PR TITLE
chore: refine Docker image caching strategy for main branch

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -50,6 +50,10 @@ jobs:
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
                   cache-from: |
-                      type=gha
+                      # Only use GHA cache for main branch
+                      type=gha,scope=${{ github.ref_name == 'main' && 'main' || '' }}
+                      # Always try to use registry cache from latest
                       type=registry,ref=ghcr.io/${{ github.repository_owner }}/bino:latest
-                  cache-to: type=gha,mode=max
+                  cache-to: |
+                      # Only save GHA cache for main branch
+                      type=gha,mode=max,scope=${{ github.ref_name == 'main' && 'main' || '' }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -50,10 +50,7 @@ jobs:
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
                   cache-from: |
-                      # Only use GHA cache for main branch
                       type=gha,scope=${{ github.ref_name == 'main' && 'main' || '' }}
-                      # Always try to use registry cache from latest
                       type=registry,ref=ghcr.io/${{ github.repository_owner }}/bino:latest
                   cache-to: |
-                      # Only save GHA cache for main branch
                       type=gha,mode=max,scope=${{ github.ref_name == 'main' && 'main' || '' }}

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -52,5 +52,4 @@ jobs:
                   cache-from: |
                       type=gha,scope=${{ github.ref_name == 'main' && 'main' || '' }}
                       type=registry,ref=ghcr.io/${{ github.repository_owner }}/bino:latest
-                  cache-to: |
-                      type=gha,mode=max,scope=${{ github.ref_name == 'main' && 'main' || '' }}
+                  cache-to: ${{ github.ref_name == 'main' && 'type=gha,mode=max' || '' }}


### PR DESCRIPTION
Updated the Docker CI workflow to conditionally use GHA cache and save cache only for the main branch, improving cache management and build efficiency.

## What kind of change is this?

- [ ] feat: (new feature)
- [ ] fix: (bug fix)
- [x] chore: (updates to dependencies or build processes)
- [ ] docs: (documentation changes)
- [ ] style: (formatting, missing semi colons, etc; no code change)
- [ ] refactor: (refactoring production code)
- [ ] test: (adding tests, refactoring tests; no production code change)
- [ ] perf: (performance improvements)
