### PR TITLE
refactor(twitter): replace generateTextWithTools with generateObject

### DIFF
--- a/packages/client-twitter/__tests__/post.test.ts
+++ b/packages/client-twitter/__tests__/post.test.ts
@@ -3,9 +3,9 @@ import {
     IAgentRuntime,
     elizaLogger,
     generateMessageResponse,
-    generateTextWithTools,
     Content,
     State,
+    generateObject,
 } from "@elizaos/core";
 
 import { TwitterPostClient } from "../src/post";
@@ -31,10 +31,10 @@ vi.mock("@elizaos/core", async () => {
             info: vi.fn(),
             debug: vi.fn(),
         },
+        generateObject: vi.fn(),
         generateText: vi.fn(),
         composeContext: vi.fn().mockReturnValue("mocked context"),
         generateMessageResponse: vi.fn(),
-        generateTextWithTools: vi.fn(),
     };
 });
 
@@ -91,9 +91,17 @@ describe("Twitter Post Client", () => {
             }
 
             // Mock the quicksilver response
-            vi.mocked(generateTextWithTools).mockResolvedValue(
-                "Quicksilver oracle response"
-            );
+            vi.mocked(generateObject).mockResolvedValueOnce({
+                object: {
+                    question: "Quicksilver oracle response",
+                },
+            } as any);
+            // Mock the fetch response for quicksilver
+            global.fetch = vi.fn().mockResolvedValueOnce({
+                json: async () => ({
+                    data: "Quicksilver oracle response",
+                }),
+            });
 
             // Mock the final message response
             vi.mocked(generateMessageResponse).mockResolvedValue({

--- a/packages/core/src/generation.ts
+++ b/packages/core/src/generation.ts
@@ -867,8 +867,7 @@ export async function generateTextWithTools({
     const model = getModel(provider, modelSettings.name);
     const TOOL_CALL_LIMIT = 5;
 
-    const qsres = [];
-    await aiGenerateText({
+    const result = await aiGenerateText({
         model,
         system: customSystemPrompt ?? runtime.character?.system ?? undefined,
         tools: buildToolSet(tools),
@@ -876,19 +875,11 @@ export async function generateTextWithTools({
         experimental_continueSteps: true,
         onStepFinish(step: any) {
             logStep(step);
-            const roundtableResults = step.toolResults.filter(
-                (res: any) => res.toolName === "roundtable"
-            );
-            if (roundtableResults.length > 0) {
-                qsres.push(roundtableResults[0]);
-            }
         },
         ...modelOptions,
     });
 
-    const result = qsres[qsres.length - 1]?.result ?? "";
-    console.log("result: ", result);
-    return result;
+    return result.text;
 }
 
 function buildToolSet(


### PR DESCRIPTION
replace generateTextWithTools with generateObject in Twitter Post Client

- Updated the TwitterPostClient to utilize generateObject instead of generateTextWithTools for improved clarity and functionality.
- Renamed the askQuicksilver method to askOracle to better reflect its purpose.
- Enhanced test coverage by mocking generateObject in the associated test file.

# Relates to

# Risks

# Background

## What does this PR do?

## What kind of change is this?

- [ ] feat: (new feature)
- [ ] fix: (bug fix)
- [ ] chore: (updates to dependencies or build processes)
- [ ] docs: (documentation changes)
- [ ] style: (formatting, missing semi colons, etc; no code change)
- [ ] refactor: (refactoring production code)
- [ ] test: (adding tests, refactoring tests; no production code change)
- [x] perf: (performance improvements)
