### PR TITLE
refactor(ragknowledge): improve knowledge retrieval with early returns

### DIFF
--- a/packages/core/src/ragknowledge.ts
+++ b/packages/core/src/ragknowledge.ts
@@ -209,6 +209,12 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
         // Keep the match with highest score when duplicates are found
         const uniqueMatches = this.filterDuplicatesByInputHash(filteredMatches);
 
+        // If we have no matches that meet the threshold, return empty array
+        if (uniqueMatches.length === 0) {
+            elizaLogger.debug("No matches found with score above threshold");
+            return [];
+        }
+
         const ids = uniqueMatches.map((match) => match.id as UUID);
 
         const chunks = await this.runtime.databaseAdapter.getKnowledgeByIds({


### PR DESCRIPTION
## What does this PR do?
- Added early return checks in `getKnowledgeByIds` to handle empty IDs array, enhancing robustness and clarity in database queries.
- Implemented a check in `RAGKnowledgeManager` to return an empty array if no matches meet the score threshold, improving the efficiency of knowledge retrieval.

## What kind of change is this?

- [ ] feat: (new feature)
- [x] fix: (bug fix)
- [ ] chore: (updates to dependencies or build processes)
- [ ] docs: (documentation changes)
- [ ] style: (formatting, missing semi colons, etc; no code change)
- [ ] refactor: (refactoring production code)
- [ ] test: (adding tests, refactoring tests; no production code change)
- [ ] perf: (performance improvements)
