### PR TITLE
refactor(ragknowledge, vectorDB): update knowledge filter

### DIFF
--- a/packages/core/src/ragknowledge.ts
+++ b/packages/core/src/ragknowledge.ts
@@ -170,7 +170,7 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
             namespace: this.runtime.agentId.toString(),
             vector: getDimentionZeroEmbedding(),
             topK: 1,
-            type: KNOWLEDGE_METADATA_TYPE,
+            type: { $ne: "messages" },
             filter: {
                 inputHash,
             },
@@ -197,7 +197,7 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
             namespace: params.agentId.toString(),
             vector: embedding,
             topK: match_count,
-            type: KNOWLEDGE_METADATA_TYPE,
+            type: { $ne: "messages" },
             filter: {},
         });
 
@@ -208,7 +208,6 @@ export class RAGKnowledgeManager implements IRAGKnowledgeManager {
         );
 
         // Filter out duplicates based on inputHash
-        // Keep the match with highest score when duplicates are found
         const uniqueMatches = this.filterDuplicatesByInputHash(filteredMatches);
 
         // If we have no matches that meet the threshold, return empty array

--- a/packages/core/src/vectorDB.ts
+++ b/packages/core/src/vectorDB.ts
@@ -41,7 +41,9 @@ export class VectorDB<T extends RecordMetadata> {
         namespace: string;
         topK: number;
         vector: number[];
-        type: string;
+        type?:
+            | string
+            | { $eq?: string; $ne?: string; $in?: string[]; $nin?: string[] };
         filter: RecordMetadata;
     }): Promise<ScoredPineconeRecord<T>[]> {
         const results = await this.index.namespace(params.namespace).query({


### PR DESCRIPTION
## What does this PR do?

- Modified the type definition for the `type` property in the VectorDB class to allow for more flexible query conditions, enhancing the query capabilities.
- Updated the RAGKnowledgeManager to filter out knowledge entries with a type of "messages", improving the relevance of retrieved knowledge.
- These changes promote better code clarity and maintainability while adhering to the principles of Clean Code.

## What kind of change is this?

- [x] feat: (new feature)
- [ ] fix: (bug fix)
- [ ] chore: (updates to dependencies or build processes)
- [ ] docs: (documentation changes)
- [ ] style: (formatting, missing semi colons, etc; no code change)
- [ ] refactor: (refactoring production code)
- [ ] test: (adding tests, refactoring tests; no production code change)
- [ ] perf: (performance improvements)
